### PR TITLE
Fetch Trophy Group Info and Trophies by Group ID

### DIFF
--- a/include/Trophies.php
+++ b/include/Trophies.php
@@ -14,7 +14,7 @@ class Trophy
 
     //Returns all the trophies that the current logged in user has earned
     public function GetMyTrophies($Limit = 36)
-    {        
+    {
         $headers = array(
             'Authorization: Bearer ' . $this->oauth,
         );
@@ -25,7 +25,7 @@ class Trophy
 
         return $data;
     }
-    
+
     //Returns all trophies from a game based on it's game ID (ex. NPWR07466_00)
     public function GetGameTrophies($GameID)
     {
@@ -34,6 +34,32 @@ class Trophy
         );
 
         $response = \Utilities::SendRequest(TROPHY_URL . "trophyTitles/" . $GameID . "/trophyGroups/all/trophies?fields=@default,trophyRare,trophyEarnedRate&npLanguage=en&sortKey=trophyId&iconSize=m", $headers, false, null, "GET", null);
+
+        $data = json_decode($response['body'], false);
+
+        return $data;
+    }
+
+    public function GetGameTrophiesByGroup($GameID, $GroupID)
+    {
+        $headers = array(
+            'Authorization: Bearer ' . $this->oauth,
+        );
+
+        $response = \Utilities::SendRequest(TROPHY_URL . "trophyTitles/" . $GameID . "/trophyGroups/" . $GroupID . "/trophies?fields=@default,trophyRare,trophyEarnedRate&npLanguage=en&sortKey=trophyId&iconSize=m", $headers, false, null, "GET", null);
+
+        $data = json_decode($response['body'], false);
+
+        return $data;
+    }
+
+    public function GetGameTrophyGroups($GameID)
+    {
+        $headers = array(
+            'Authorization: Bearer ' . $this->oauth,
+        );
+
+        $response = \Utilities::SendRequest(TROPHY_URL . "trophyTitles/" . $GameID . "/trophyGroups/?npLanguage=en", $headers, false, null, "GET", null);
 
         $data = json_decode($response['body'], false);
 


### PR DESCRIPTION
Allows fetching of the different trophy groups (DLC) for a game ID, and
then allows specific trophy lists to be retrieved for those IDs.