### PR TITLE
hasPlayed should always return boolean

### DIFF
--- a/src/Api/Game.php
+++ b/src/Api/Game.php
@@ -252,9 +252,9 @@ class Game extends AbstractApi
     public function hasPlayed() : bool
     {
         if ($this->comparing() && isset($this->trophyInfo()->comparedUser)) {
-            return $this->trophyInfo()->comparedUser;
+            return (bool) $this->trophyInfo()->comparedUser;
         } else if (isset($this->trophyInfo()->fromUser)) {
-            return $this->trophyInfo()->fromUser;
+            return (bool) $this->trophyInfo()->fromUser;
         }
 
         return false;


### PR DESCRIPTION
Both type docs and method name suggest the hasPlayed method in game.php should always return a boolean. This is only true in the case that the user has not played a game. When a user has, the trophy info (object) is returned. This pr aims to cast the result to a boolean so that the result of the method is compliant with the type docs and method name.