### PR TITLE
Add composer install for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: php
 php:
-- '7.2'
-script: phpunit --configuration phpunit.xml
+  - '7.2'
+install:
+  - composer self-update
+  - composer install
+script: 
+  - phpunit --configuration phpunit.xml


### PR DESCRIPTION
Travis is failing because a composer install is needed. This will run composer install for every check.