### PR TITLE
Get user games via trophies

### DIFF
--- a/src/Api/User.php
+++ b/src/Api/User.php
@@ -293,7 +293,7 @@ class User extends AbstractApi
         $data = [
             'comparedUser' => $this->onlineIdParameter(),
             'fields' => '@default,trophyTitleSmallIconUrl',
-            'limit' => $limit, // 128 is max
+            'limit' => min($limit, 128), // 128 is max
             'npLanguage' => $language,
             'offset' => $offset,
             'platform' => 'PS3,PS4,PSVITA'

--- a/src/Api/User.php
+++ b/src/Api/User.php
@@ -284,6 +284,25 @@ class User extends AbstractApi
     }
 
     /**
+     * Gets the User's latest games via trophies. This includes all consoles (PS3, PS4 and PS Vita).
+     *
+     * @return object
+     */
+    public function trophies($offset = 0, $language = 'en', $limit = 128) : \stdClass
+    {
+        $data = [
+			'comparedUser' => $this->onlineIdParameter(),
+            'fields' => '@default,trophyTitleSmallIconUrl',
+			'limit' => $limit, // 128 is max
+            'npLanguage' => $language,
+			'offset' => $offset,
+			'platform' => 'PS3,PS4,PSVITA'
+        ];
+        
+        return $this->get(sprintf(Trophy::TROPHY_ENDPOINT . 'trophyTitles'), $data);
+    }
+    
+    /**
      * Gets the User's Games played.
      *
      * @return array Array of Api\Game.

--- a/src/Api/User.php
+++ b/src/Api/User.php
@@ -291,12 +291,12 @@ class User extends AbstractApi
     public function trophies($offset = 0, $language = 'en', $limit = 128) : \stdClass
     {
         $data = [
-			'comparedUser' => $this->onlineIdParameter(),
+            'comparedUser' => $this->onlineIdParameter(),
             'fields' => '@default,trophyTitleSmallIconUrl',
-			'limit' => $limit, // 128 is max
+            'limit' => $limit, // 128 is max
             'npLanguage' => $language,
-			'offset' => $offset,
-			'platform' => 'PS3,PS4,PSVITA'
+            'offset' => $offset,
+            'platform' => 'PS3,PS4,PSVITA'
         ];
         
         return $this->get(sprintf(Trophy::TROPHY_ENDPOINT . 'trophyTitles'), $data);

--- a/src/Api/User.php
+++ b/src/Api/User.php
@@ -288,7 +288,7 @@ class User extends AbstractApi
      *
      * @return object
      */
-    public function trophies($offset = 0, $language = 'en', $limit = 128) : \stdClass
+    public function trophyTitles($offset = 0, $language = 'en', $limit = 128) : \stdClass
     {
         $data = [
             'comparedUser' => $this->onlineIdParameter(),


### PR DESCRIPTION
The current games() function only returns PS4 titles. By going via the trophies endpoint so do we get from all consoles: PS3, PS4 and PS Vita.