### PR TITLE
Search on store fix

### DIFF
--- a/src/Model/Store/Concept.php
+++ b/src/Model/Store/Concept.php
@@ -17,7 +17,7 @@ class Concept extends Model
 
     public static function fromObject(Client $client, object $data)
     {
-        $instance = new Concept($client, $data->conceptId);
+        $instance = new Concept($client, $data->conceptId ?? 0);
         $instance->setCache($data);
 
         return $instance;

--- a/tests/Client/Factories/StoreTestFactory.php
+++ b/tests/Client/Factories/StoreTestFactory.php
@@ -20,9 +20,14 @@ class StoreTestFactory
                 'id' => random_int(1111, 9999),
                 'conceptProductMetadata' => [
                     'id' => random_int(1111, 9999),
-                    'conceptId' => random_int(1111, 9999),
+                    'name' => 'Random name',
+                    'leadPublisherName' => 'Random Publisher',
                 ]
             ];
+
+            if (random_int(0, 1)) {
+                $item['conceptProductMetadata']['conceptId'] = random_int(1111, 9999);
+            }
 
             $items[] = json_decode(json_encode($item, JSON_THROW_ON_ERROR), false, 512, JSON_THROW_ON_ERROR);
         }

--- a/tests/Client/Factories/StoreTestFactory.php
+++ b/tests/Client/Factories/StoreTestFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Client\Factories;
+
+class StoreTestFactory
+{
+    /**
+     * Return dummy data for store products
+     *
+     * @param int $amount
+     * @return array
+     * @throws \Exception
+     */
+    public function emptyDataProducts(int $amount): array
+    {
+        $items = [];
+
+        for ($i = 0 ; $i < $amount ; $i++) {
+            $item = [
+                'id' => random_int(1111, 9999),
+                'conceptProductMetadata' => [
+                    'id' => random_int(1111, 9999),
+                    'conceptId' => random_int(1111, 9999),
+                ]
+            ];
+
+            $items[] = json_decode(json_encode($item, JSON_THROW_ON_ERROR), false, 512, JSON_THROW_ON_ERROR);
+        }
+
+        return $items;
+    }
+}

--- a/tests/Client/StoreTest.php
+++ b/tests/Client/StoreTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\UseCases;
 
+use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 use Tests\Client\Factories\StoreTestFactory;
-use Tustin\PlayStation\Client;
 use Tustin\PlayStation\Factory\StoreFactory;
 use Tustin\PlayStation\Iterator\StoreSearchIterator;
 use Tustin\PlayStation\Model\Store\Concept;
@@ -31,7 +31,8 @@ class StoreTest extends TestCase
         $items = (new StoreTestFactory)->emptyDataProducts(100);
         $products->update(count($items), $items, null);
 
-        while($products->valid()) {
+        while ($products->valid()) {
+            $products->current()->conceptId();
             $products->next();
         }
 

--- a/tests/Client/StoreTest.php
+++ b/tests/Client/StoreTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\UseCases;
+
+use PHPUnit\Framework\TestCase;
+use Tests\Client\Factories\StoreTestFactory;
+use Tustin\PlayStation\Client;
+use Tustin\PlayStation\Factory\StoreFactory;
+use Tustin\PlayStation\Iterator\StoreSearchIterator;
+use Tustin\PlayStation\Model\Store\Concept;
+
+class StoreTest extends TestCase
+{
+    /**
+     * Fetches an n amount from the store and update the cache when necessary.
+     *
+     * @return void
+     * @throws \Exception
+     *
+     * @test
+     */
+    public function store_search_iterator(): void
+    {
+        $factory = $this->createMock(StoreFactory::class);
+
+        $products = $this->getMockBuilder(StoreSearchIterator::class)
+            ->setConstructorArgs([$factory, 'searchTerm'])
+            ->onlyMethods(['access'])
+            ->getMock();
+
+        $items = (new StoreTestFactory)->emptyDataProducts(100);
+        $products->update(count($items), $items, null);
+
+        while($products->valid()) {
+            $products->next();
+        }
+
+        echo 'Executed ' . $products->key() . ' times.';
+        $this->assertEquals(count($items), $products->key());
+    }
+}


### PR DESCRIPTION
# Store Search Iterator

## DivisionByZeroError

The first problem I found was the `$limit` variable has not been set in `StoreFactoryIterator` causing the modulo always a division by zero. I chose to keep the limit of `20` because this is the `pageSize` limit. Also change the `'pageSize' => 20` to `'pageSize' => $limit` on `access()` method.

## maxEventIndexCursor

The next problem was the `maxEventIndexCursor`, there is neither a property nor a method called `maxEventIndexCursor`, changing the undefined variable to `customCursor` which is a valid property containing the `cursor` it keeps the pagination until the end.

# Undefined concept ID

The problem here is a bit simple, I got into a similar one crawling through the Chihiro API.

Some content, when querying data through the API could be `DISC ONLY` or `DISC BASED GAME` in `storePrimaryClassification`, it commonly happens in expansions from Rock Band but happens in other old games, as far as I know recent games does not have this problem.

An easy fix is just check if it exists before calling `Concept` and pass `0` or `null` in case it does not exist, all the other data will be fetched equally except for `conceptID`.

The search I made was:

```php
$product = $client->store()->search('crash');
```

# Unit Test

I made a unit test also, but since I'm not so familiar with mocking classes, I think it is a pretty weak test and probably inefficient.