### PR TITLE
Concept null data when fetched through gameList fix

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -48,6 +48,19 @@ abstract class Model extends Api
     }
 
     /**
+     * Return strictly a string in case pluck return a null value.
+     * Some Concept could have empty values when fetched through gameList()
+     *
+     * @param string $property
+     * @param bool $ignoreCache Ignores the existing cache and fetches fresh API data.
+     * @return string
+     */
+    final protected function issetPluck(string $property, bool $ignoreCache = false): string
+    {
+        return $this->pluck($property, $ignoreCache) ?? '';
+    }
+
+    /**
      * Plucks an API property from the cache. Will populate cache if necessary.
      *
      * @param string $property

--- a/src/Model/Store/Concept.php
+++ b/src/Model/Store/Concept.php
@@ -25,12 +25,12 @@ class Concept extends Model
 
     public function productId(): string
     {
-        return $this->pluck('id');
+        return $this->issetPluck('id');
     }
 
     public function name(): string
     {
-        return $this->pluck('name');
+        return $this->issetPluck('name');
     }
 
     public function conceptId(): string
@@ -40,7 +40,7 @@ class Concept extends Model
 
     public function publisher(): string
     {
-        return ($this->pluck('publisherName') ?? $this->pluck('leadPublisherName'));
+        return ($this->issetPluck('publisherName') ?? $this->issetPluck('leadPublisherName'));
     }
 
 	public function fetch(): object

--- a/tests/GameList.php
+++ b/tests/GameList.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+use Tustin\PlayStation\Model\Store\Concept;
+use function PHPUnit\Framework\assertIsString;
+
+class GameList extends TestCase
+{
+    /** @test */
+    public function concept_pluck_with_null_data()
+    {
+        $mock = $this->getMockBuilder(Concept::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['pluck'])
+            ->getMock();
+
+        // Some concept fetch from gameList has no properties
+        $mock->method('pluck')->willReturn(null);
+
+        $productId = $mock->productId();
+        $name = $mock->name();
+        $conceptId = $mock->publisher();
+
+        $this->assertIsString($productId);
+        $this->assertIsString($name);
+        $this->assertIsString($conceptId);
+    }
+}


### PR DESCRIPTION
# Problem

When fetching `Concepts` through `gameList` some apps have the `concept id` but has no other information to be plucked, this often occur when fetching non-game apps, like HBO, Spotify, Netflix...

At `JsonStream.php:39, Tustin\Haste\Http\JsonStream->jsonSerialize()` you can catch an error on store front with message `Store Front: There is no required storefront for this concept.` and error code `3162368` maybe it could be useful implement an Exception to handle some errors.

The concept is:

```php
"concept": {
    "id": 221898,
    "name": "HBO Max",
    "country": "US",
    "language": "en"
  }
  ...
}
```

## Stack trace

I traced the problem until the `jsonSerialize()` where the `conceptRetrieve` is null, this value returned to `Concept` will throw the error since it's expecting a string.

```php
JsonStream.php:39, Tustin\Haste\Http\JsonStream->jsonSerialize()
HttpClient.php:37, Tustin\Haste\Http\HttpClient->get()
Api.php:48, Tustin\PlayStation\Api->graphql()
Concept.php:50, Tustin\PlayStation\Model\Store\Concept->fetch()
Model.php:42, Tustin\PlayStation\Model->performFetch()
Model.php:69, Tustin\PlayStation\Model->pluck()
Concept.php:43, Tustin\PlayStation\Model\Store\Concept->publisher()
```

```json
{
    "conceptRetrieve": null
}
```

# Solution

My solution was, instead of modify the `pluck()` create another function on model to handle the null values and always return a string to avoid side effects on other classes.

Also I created the unit test for the `Concept` null values.