### PR TITLE
User profile fix

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -22,7 +22,7 @@ class User extends Model
     /**
      * Constructs a new user object.
      *
-     * @param UsersFactory $usersFactory
+     * @param Client $client
      * @param string $accountId
      */
     public function __construct(Client $client, string $accountId)
@@ -32,7 +32,7 @@ class User extends Model
         $this->accountId = $accountId;
     }
 
-    public static function fromObject(Client $client, object $data)
+    public static function fromObject(Client $client, object $data): User
     {
         $instance = new User($client, $data->accountId);
         $instance->setCache($data);
@@ -86,7 +86,7 @@ class User extends Model
 
         $results = $this->get('trophy/v1/users/' . $this->accountId() . '/titles/trophyTitles', $body);
 
-        if (count($results->titles[0]->trophyTitles) == 0) {
+        if (count($results->titles[0]->trophyTitles) === 0) {
             return '';
         }
 
@@ -235,7 +235,7 @@ class User extends Model
      */
     public function languages(): array
     {
-        return $this->pluck('languagesUsed');
+        return $this->pluck('languages');
     }
 
     /**

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -41,6 +41,22 @@ class User extends Model
     }
 
     /**
+     * TODO - This can be improved, only a temporary method
+     *
+     * Check if a plucked value is equal to the expected.
+     * Some pluck methods get a null response and parse it into a bool returning a false-positive.
+     *
+     * @param string $pluckVal
+     * @param string|null $expectVal
+     * @param bool $isEqual
+     * @return bool
+     */
+    private function isValidResponse(string $pluckVal, ?string $expectVal, bool $isEqual = true): bool
+    {
+        return $isEqual ? $pluckVal === $expectVal : $pluckVal !== $expectVal;
+    }
+
+    /**
      * Get the trophy titles associated with this user's account.
      * 
      * @return TrophyTitlesFactory
@@ -267,7 +283,11 @@ class User extends Model
      */
     public function isCloseFriend(): bool
     {
-        return $this->pluck('personalDetail') !== null;
+        return $this->isValidResponse(
+            $this->pluck('personalDetail'),
+            null,
+            false
+        );
     }
 
     /**
@@ -279,7 +299,10 @@ class User extends Model
      */
     public function hasFriendRequested(): bool
     {
-        return $this->pluck('friendRelation') === 'requesting';
+        return $this->isValidResponse(
+            $this->pluck('friendRelation'),
+            'requesting'
+        );
     }
 
     /**
@@ -289,7 +312,10 @@ class User extends Model
      */
     public function isOnline(): bool
     {
-        return $this->pluck('presences.0.onlineStatus') === 'online';
+        return $this->isValidResponse(
+            $this->pluck('presences.0.onlineStatus'),
+            'online'
+        );
     }
 
     /**

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tustin\PlayStation\Model\User;
+
+class UserTest extends TestCase
+{
+    /**
+     * @var MockObject|User
+     */
+    protected $user;
+
+    protected function setUp(): void
+    {
+        $this->user = $this->getMockBuilder(User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['fetch', 'accountId'])
+            ->getMock();
+
+        // Data response from 'userProfile/v1/internal/users/[accountId]/profiles'
+        $data = [
+            'onlineId' => 'psnusername',
+            'aboutMe' => '',
+            'avatars' => [],
+            'languages' => [],
+            'isPlus' => true,
+            'isOfficiallyVerified' => false,
+            'isMe' => false,
+        ];
+
+        $this->user->method('fetch')->willReturn((object)$data);
+        $this->user->method('accountId')->willReturn('0123456789');
+    }
+
+    /**
+     *  Try pluck data from onlineId().
+     *
+     * @test
+     */
+    public function pluck_onlineId(): void
+    {
+        $onlineId = $this->user->onlineId();
+        $this->assertIsString($onlineId);
+    }
+
+    /**
+     *  Try pluck data from aboutMe().
+     *
+     * @test
+     */
+    public function pluck_aboutMe(): void
+    {
+        $aboutMe = $this->user->aboutMe();
+        $this->assertIsString($aboutMe);
+    }
+
+    /**
+     *  Try pluck data from accountId().
+     *
+     * @test
+     */
+    public function pluck_accountId(): void
+    {
+        $accountId = $this->user->accountId();
+        $this->assertIsString($accountId);
+    }
+
+    /**
+     *  Try pluck data from avatarUrls().
+     *
+     * @test
+     */
+    public function pluck_avatarUrls(): void
+    {
+        $avatarUrls = $this->user->avatarUrls();
+        $this->assertIsArray($avatarUrls);
+    }
+
+    /**
+     *  Try pluck data from avatarUrl().
+     *
+     * @test
+     */
+    public function pluck_avatarUrl(): void
+    {
+        $avatarUrl = $this->user->avatarUrl();
+        $this->assertIsString($avatarUrl);
+    }
+
+    /**
+     *  Try pluck data from isBlocking().
+     *
+     * @test
+     */
+    public function pluck_isBlocking(): void
+    {
+        $isBlocking = $this->user->isBlocking();
+        $this->assertIsBool($isBlocking);
+    }
+
+    /**
+     *  Try pluck data from followerCount().
+     *
+     * @test
+     */
+    public function pluck_followerCount(): void
+    {
+        $followerCount = $this->user->followerCount();
+        $this->assertIsInt($followerCount);
+    }
+
+    /**
+     *  Try pluck data from isFollowing().
+     *
+     * @test
+     */
+    public function pluck_isFollowing(): void
+    {
+        $isFollowing = $this->user->isFollowing();
+        $this->assertIsBool($isFollowing);
+    }
+
+    /**
+     *  Try pluck data from isVerified().
+     *
+     * @test
+     */
+    public function pluck_isVerified(): void
+    {
+        $isVerified = $this->user->isVerified();
+        $this->assertIsBool($isVerified);
+    }
+
+    /**
+     *  Try pluck data from languages().
+     *
+     * @test
+     */
+    public function pluck_languages(): void
+    {
+        $languages = $this->user->languages();
+        $this->assertIsArray($languages);
+    }
+
+    /**
+     *  Try pluck data from mutualFriendCount().
+     *
+     * @test
+     */
+    public function pluck_mutualFriendCount(): void
+    {
+        $mutualFriendCount = $this->user->mutualFriendCount();
+        $this->assertIsInt($mutualFriendCount);
+    }
+
+    /**
+     *  Try pluck data from hasMutualFriends().
+     *
+     * @test
+     */
+    public function pluck_hasMutualFriends(): void
+    {
+        $hasMutualFriends = $this->user->hasMutualFriends();
+        $this->assertIsBool($hasMutualFriends);
+    }
+
+    /**
+     *  Try pluck data from isCloseFriend().
+     *
+     * @test
+     */
+    public function pluck_isCloseFriend(): void
+    {
+        $isCloseFriend = $this->user->isCloseFriend();
+        $this->assertIsBool($isCloseFriend);
+    }
+
+    /**
+     *  Try pluck data from hasFriendRequested().
+     *
+     * @test
+     */
+    public function pluck_hasFriendRequested(): void
+    {
+        $hasFriendRequested = $this->user->hasFriendRequested();
+        $this->assertIsBool($hasFriendRequested);
+    }
+
+    /**
+     *  Try pluck data from isOnline().
+     *
+     * @test
+     */
+    public function pluck_isOnline(): void
+    {
+        $isOnline = $this->user->isOnline();
+        $this->assertIsBool($isOnline);
+    }
+
+    /**
+     *  Try pluck data from hasPlus().
+     *
+     * @test
+     */
+    public function pluck_hasPlus(): void
+    {
+        $hasPlus = $this->user->hasPlus();
+        $this->assertIsBool($hasPlus);
+    }
+
+    /**
+     * Test fetch() method
+     *
+     * @test
+     */
+    public function fetch_user_data(): void
+    {
+        $data = $this->user->fetch();
+        $this->assertIsObject($data);
+    }
+}

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -221,4 +221,14 @@ class UserTest extends TestCase
         $data = $this->user->fetch();
         $this->assertIsObject($data);
     }
+
+    public function test_trophyTitles() {/* TODO - Unit test */ }
+
+    public function test_gameList() {/* TODO - Unit test */ }
+
+    public function test_friends() {/* TODO - Unit test */ }
+
+    public function test_titleIdToCommunicationId() {/* TODO - Unit test */ }
+
+    public function test_trophySummary() {/* TODO - Unit test */ }
 }


### PR DESCRIPTION
# Languages

The `languages` were using the property `languagesUsed` to pluck the languages, just a change for the new property value of `languages` solves the problem.

# Deprecated methods

The call to endpoint `'userProfile/v1/internal/users/[accountId]/profiles'` gives the response of

```json
{
   "onlineId": "Username",
   "aboutMe": "",
   "avatars": [],
   "languages": [],
   "isPlus": true,
   "isOfficiallyVerified": false,
   "isMe": false
}
```

So these methods seems to be deprecated in this version, but as I'm not completely sure about this I decided to not set them as `@deprecated`:

- `mutualFriendCount()`
- `hasMutualFriends()`
- `isCloseFriend()`
- `hasFriendRequested()`
- `isOnline()`
- `isBlocking()`
- `followerCount()`
- `isFollowing()`

But created a method to solve the `false-postivie` return from these:

- `isOnline()`
- `hasFriendRequest()`
- `isCloseFriend()`

Also created a UnitTest for those profile values.