### PR TITLE
Switch BASE_URL to new TLD.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -15,7 +15,7 @@ use Tustin\Haste\Http\Middleware\AuthenticationMiddleware;
 class Client extends AbstractClient
 {
     const AUTH_URL = 'https://ca.account.sony.com/api/';
-    const BASE_URL = 'https://m.np.playstation.net/api/';
+    const BASE_URL = 'https://m.np.playstation.com/api/';
 
     private $accessToken;
     private $refreshToken;


### PR DESCRIPTION
It looks like Sony has finally turned off the `.net` base domain. I've tested this with universal search and seems to function as expected.