### PR TITLE
Enforce PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,10 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "^7.0",
-        "php": "^7.4|^8.0|^8.1",
-        "tustin/haste": "^1.0.8",
-        "nesbot/carbon": "^2.41",
-        "myclabs/php-enum": "^1.7"
+        "guzzlehttp/guzzle": "^7.5",
+        "php": "^8.1",
+        "tustin/haste": "^1.1",
+        "nesbot/carbon": "^2.41"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/src/Api.php
+++ b/src/Api.php
@@ -13,7 +13,7 @@ class Api extends HttpClient
         $this->httpClient = $client;
     }
 
-    public function graphql(string $op, array $variables)
+    public function graphql(string $op, array $variables): object
     {
         // @Temp: This will hopefully be removed at some point for dynamic operation hashing.
         $hashMap = [

--- a/src/Enum/CloudStatusType.php
+++ b/src/Enum/CloudStatusType.php
@@ -2,10 +2,8 @@
 
 namespace Tustin\PlayStation\Enum;
 
-use MyCLabs\Enum\Enum;
-
-class CloudStatusType extends Enum
+enum CloudStatusType: string
 {
-    private const uploading = 'uploading';
-    private const active = 'active';
+    case Uploading = 'uploading';
+    case Active = 'active';
 }

--- a/src/Enum/ConsoleType.php
+++ b/src/Enum/ConsoleType.php
@@ -2,12 +2,10 @@
 
 namespace Tustin\PlayStation\Enum;
 
-use MyCLabs\Enum\Enum;
-
-class ConsoleType extends Enum
+enum ConsoleType: string
 {
-    private const vita = 'PSVITA';
-    private const ps3 = 'PS3';
-    private const ps4 = 'PS4';
-    private const ps5 = 'PS5';
+    case Vita = 'PSVITA';
+    case PS3 = 'PS3';
+    case PS4 = 'PS4';
+    case PS5 = 'PS5';
 }

--- a/src/Enum/LanguageType.php
+++ b/src/Enum/LanguageType.php
@@ -1,39 +1,37 @@
 <?php
 namespace Tustin\PlayStation\Enum;
 
-use MyCLabs\Enum\Enum;
-
-class LanguageType extends Enum
+enum LanguageType: string
 {
-    private const english = 'en';
-    private const czech = 'cs';
-    private const danish = 'da';
-    private const german = 'de';
-    private const english_uk = 'en-GB';
-    private const english_us = 'en-US';
-    private const spanish = 'es'; //Spain
-    private const latin_america = 'es-MX';
-    private const french = 'fr';
-    private const french_canada = 'fr-CA'; // Canada (Quebec)
-    private const indonesian = 'id';
-    private const italian = 'it';
-    private const hungarian = 'hu';
-    private const dutch = 'nl';
-    private const norwegian = 'no';
-    private const polish = 'pl';
-    private const portuguese_brazil = 'pt-BR';
-    private const portuguese_portugal = 'pt';
-    private const russian = 'ru';
-    private const romanian = 'ro';
-    private const finnish = 'fi';
-    private const swedish = 'sv';
-    private const vietnamese = 'vi';
-    private const turkish = 'tr';
-    private const arabic = 'ar';
-    private const greek = 'el';
-    private const japanese = 'ja';
-    private const korean = 'ko';
-    private const thai = 'th';
-    private const chinese_simplified = 'zh-CN';
-    private const chinese_taiwan = 'zh-TW';
+    case English = 'en';
+    case Czech = 'cs';
+    case Danish = 'da';
+    case German = 'de';
+    case EnglishUK = 'en-GB';
+    case EnglishUS = 'en-US';
+    case Spanish = 'es'; //Spain
+    case LatinAmerica = 'es-MX';
+    case French = 'fr';
+    case FrenchCanada = 'fr-CA'; // Canada (Quebec)
+    case Indonesian = 'id';
+    case Italian = 'it';
+    case Hungarian = 'hu';
+    case Dutch = 'nl';
+    case Norwegian = 'no';
+    case Polish = 'pl';
+    case PortugueseBrazil = 'pt-BR';
+    case PortuguesePortugal = 'pt';
+    case Russian = 'ru';
+    case Romanian = 'ro';
+    case Finnish = 'fi';
+    case Swedish = 'sv';
+    case Vietnamese = 'vi';
+    case Turkish = 'tr';
+    case Arabic = 'ar';
+    case Greek = 'el';
+    case Japanese = 'ja';
+    case Korean = 'ko';
+    case Thai = 'th';
+    case ChineseSimplified = 'zh-CN';
+    case ChineseTaiwan = 'zh-TW';
 }

--- a/src/Enum/MessageType.php
+++ b/src/Enum/MessageType.php
@@ -2,19 +2,17 @@
 
 namespace Tustin\PlayStation\Enum;
 
-use MyCLabs\Enum\Enum;
-
-class MessageType extends Enum
+enum MessageType: int
 {
-    private const text = 1;
-    private const image = 3;
-    private const video = 210;
-    private const audio = 1011;
-    private const sticker = 1013;
-    private const leftGroup = 2002;
-    private const changedGroupImage = 2004;
-    private const startedVoiceChat = 2020;
+    case Text = 1;
+    case Image = 3;
+    case Video = 210;
+    case Audio = 1011;
+    case Sticker = 1013;
+    case LeftGroup = 2002;
+    case ChangedGroupImage = 2004;
+    case StartedVoiceChat = 2020;
 
     // @TODO: Need to map out all of these events.
-    private const unknown = -1;
+    case Unknown = -1;
 }

--- a/src/Enum/SessionType.php
+++ b/src/Enum/SessionType.php
@@ -2,12 +2,10 @@
 
 namespace Tustin\PlayStation\Enum;
 
-use MyCLabs\Enum\Enum;
-
-class SessionType extends Enum
+enum SessionType: int
 {
     // Flags
-    private const unknown = 1;
-    private const game = 2;
-    private const party = 4;
+    case Unknown = 1;
+    case Game = 2;
+    case Party = 4;
 }

--- a/src/Enum/TranscodeStatusType.php
+++ b/src/Enum/TranscodeStatusType.php
@@ -2,10 +2,8 @@
 
 namespace Tustin\PlayStation\Enum;
 
-use MyCLabs\Enum\Enum;
-
-class TranscodeStatusType extends Enum
+enum TranscodeStatusType: string
 {
-    private const complete = 'complete';
-    private const inProgress = 'in_progress';
+    case Complete = 'complete';
+    case InProgress = 'in_progress';
 }

--- a/src/Enum/TrophyType.php
+++ b/src/Enum/TrophyType.php
@@ -1,12 +1,10 @@
 <?php
 namespace Tustin\PlayStation\Enum;
 
-use MyCLabs\Enum\Enum;
-
-class TrophyType extends Enum
+enum TrophyType: string
 {
-    private const platinum = 'platinum';
-    private const bronze = 'bronze';
-    private const silver = 'silver';
-    private const gold = 'gold';
+    case Platinum = 'platinum';
+    case Bronze = 'bronze';
+    case Silver = 'silver';
+    case Gold = 'gold';
 }

--- a/src/Enum/UgcType.php
+++ b/src/Enum/UgcType.php
@@ -2,10 +2,8 @@
 
 namespace Tustin\PlayStation\Enum;
 
-use MyCLabs\Enum\Enum;
-
-class UgcType extends Enum
+enum UgcType: int
 {
-    private const image = 1;
-    private const video = 2;
+    case Image = 1;
+    case Video = 2;
 }

--- a/src/Factory/FriendsListFactory.php
+++ b/src/Factory/FriendsListFactory.php
@@ -13,22 +13,13 @@ use Tustin\PlayStation\Iterator\Filter\User\VerifiedUserFilter;
 
 class FriendsListFactory extends Api implements IteratorAggregate, FactoryInterface
 {
-    /**
-     * The user.
-     *
-     * @var User
-     */
-    private $user;
-
     private string $onlineId = '';
     private bool $useCloseFriends = false;
     private bool $verified = false;
 
-    public function __construct(User $user)
+    public function __construct(private User $user)
     {
         parent::__construct($user->getHttpClient());
-
-        $this->user = $user;
     }
 
     /**

--- a/src/Factory/GameListFactory.php
+++ b/src/Factory/GameListFactory.php
@@ -12,18 +12,9 @@ use Tustin\PlayStation\Iterator\GameListIterator;
 
 class GameListFactory extends Api implements IteratorAggregate, FactoryInterface
 {
-    /**
-     * The user to get game list for.
-     *
-     * @var User|null
-     */
-    private $user;
-
-    public function __construct(User $user)
+    public function __construct(private ?User $user)
     {
         parent::__construct($user->getHttpClient());
-
-        $this->user = $user;
     }
 
     /**

--- a/src/Factory/GroupMembersFactory.php
+++ b/src/Factory/GroupMembersFactory.php
@@ -11,20 +11,12 @@ use Tustin\PlayStation\Model\Group;
 class GroupMembersFactory implements IteratorAggregate, Countable
 {
     /**
-     * @var Group
-     */
-    private $group;
-
-    /**
      * The name to filter with.
-     *
-     * @var string
      */
-    private $name;
+    private string $name;
 
-    public function __construct(Group $group)
+    public function __construct(private Group $group)
     {
-        $this->group = $group;
     }
 
     /**

--- a/src/Factory/GroupsFactory.php
+++ b/src/Factory/GroupsFactory.php
@@ -14,19 +14,13 @@ use Tustin\PlayStation\Iterator\Filter\GroupMembersFilter;
 
 class GroupsFactory extends Api implements IteratorAggregate
 {
-    private $with = [];
+    private array $with = [];
 
-    /**
-     * @var boolean
-     */
-    private $only = false;
+    private bool $only = false;
 
-    /**
-     * @var Carbon|null
-     */
-    private $since = null;
+    private ?Carbon $since = null;
 
-    public $favorited = false;
+    public bool $favorited = false;
 
     /**
      * Filters groups that only contain these onlineIds.

--- a/src/Factory/MessagesFactory.php
+++ b/src/Factory/MessagesFactory.php
@@ -13,12 +13,9 @@ use Tustin\PlayStation\Iterator\Filter\MessageTypeFilter;
 
 class MessagesFactory extends Api implements IteratorAggregate
 {
-    /**
-     * @var MessageThread
-     */
-    private $thread;
+    private MessageThread $thread;
 
-    private $typeFilter;
+    private string $typeFilter;
 
     public function __construct(MessageThread $thread)
     {
@@ -29,9 +26,6 @@ class MessagesFactory extends Api implements IteratorAggregate
 
     /**
      * Gets messages only of a certain type.
-     *
-     * @param string $class
-     * @return MessagesFactory
      */
     public function of(string $class): MessagesFactory
     {
@@ -42,8 +36,6 @@ class MessagesFactory extends Api implements IteratorAggregate
 
     /**
      * Gets the iterator and applies any filters.
-     *
-     * @return Iterator
      */
     public function getIterator(): Iterator
     {
@@ -58,8 +50,6 @@ class MessagesFactory extends Api implements IteratorAggregate
 
     /**
      * Gets the first message in the message thread.
-     *
-     * @return Message
      */
     public function first(): AbstractMessage
     {

--- a/src/Factory/MessagesFactory.php
+++ b/src/Factory/MessagesFactory.php
@@ -13,15 +13,11 @@ use Tustin\PlayStation\Iterator\Filter\MessageTypeFilter;
 
 class MessagesFactory extends Api implements IteratorAggregate
 {
-    private MessageThread $thread;
-
     private string $typeFilter;
 
-    public function __construct(MessageThread $thread)
+    public function __construct(private MessageThread $thread)
     {
         parent::__construct($thread->getHttpClient());
-
-        $this->thread = $thread;
     }
 
     /**

--- a/src/Factory/TrophyFactory.php
+++ b/src/Factory/TrophyFactory.php
@@ -9,21 +9,13 @@ use Tustin\PlayStation\Model\Trophy\TrophyGroup;
 
 class TrophyFactory implements IteratorAggregate
 {
-    /**
-     * The trophy groups' title.
-     *
-     * @var TrophyGroup
-     */
-    private $group;
-    
     private array $platforms = [];
 
     private string $withName = '';
     private string $withDetail = '';
 
-    public function __construct(TrophyGroup $group)
+    public function __construct(private TrophyGroup $group)
     {
-        $this->group = $group;
     }
 
     /**

--- a/src/Factory/TrophyGroupsFactory.php
+++ b/src/Factory/TrophyGroupsFactory.php
@@ -15,21 +15,13 @@ use Tustin\PlayStation\Iterator\Filter\TrophyGroup\TrophyTypeFilter;
 
 class TrophyGroupsFactory extends Api implements IteratorAggregate, FactoryInterface
 {
-    /**
-     * The trophy groups' title.
-     *
-     * @var AbstractTrophyTitle
-     */
-    private $title;
-
     private string $withName = '';
     private string $withDetail = '';
 
     private array $certainTrophyTypeFilter = [];
 
-    public function __construct(AbstractTrophyTitle $title)
+    public function __construct(private AbstractTrophyTitle $title)
     {
-        $this->title = $title;
     }
 
     public function withName(string $name)

--- a/src/Factory/TrophyTitlesFactory.php
+++ b/src/Factory/TrophyTitlesFactory.php
@@ -19,35 +19,22 @@ class TrophyTitlesFactory extends Api implements IteratorAggregate, FactoryInter
 {
     /**
      * Platforms for filtering.
-     *
-     * @var array
      */
-    protected $platforms = [];
+    protected array $platforms = [];
 
     /**
      * The trophy title name for filtering.
-     *
-     * @var string
      */
-    private $withName = '';
-
-    /**
-     * The user to get trophy titles for.
-     *
-     * @var User|null
-     */
-    private $user;
+    private string $withName = '';
 
     /**
      * Filter property for having trophy groups.
      * 
      * We want this to be null by default so that if the client doesn't call hasTrophyGroups, it will return all titles.
-     *
-     * @var boolean|null
      */
     private ?bool $hasTrophyGroups = null;
 
-    public function __construct(User $user)
+    public function __construct(private ?User $user)
     {
         parent::__construct($user->getHttpClient());
 
@@ -145,13 +132,13 @@ class TrophyTitlesFactory extends Api implements IteratorAggregate, FactoryInter
     /**
      * Gets the current language passed to this instance.
      * 
-     * If the language has not been set prior, this will return LanguageType::english().
+     * If the language has not been set prior, this will return LanguageType::English.
      *
      * @return LanguageType
      */
     public function getLanguage(): LanguageType
     {
-        return $this->language ?? LanguageType::english();
+        return $this->language ?? LanguageType::English;
     }
 
     /**

--- a/src/Http/ResponseParser.php
+++ b/src/Http/ResponseParser.php
@@ -15,9 +15,9 @@ class ResponseParser {
      * 3. Response - if the JSON failed and the response body was empty, the entire Response object will be returned.
      * 
      * @param Response $response
-     * @return
+     * @return mixed
      */
-    public static function parse(Response $response) 
+    public static function parse(Response $response): mixed
     {
         $contents = $response->getBody()->getContents();
         

--- a/src/Iterator/AbstractApiIterator.php
+++ b/src/Iterator/AbstractApiIterator.php
@@ -49,26 +49,19 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
 
     /**
      * Access a specific cursor in the API.
-     * 
-     * @param mixed $cursor
-     * @return void
      */
-    public abstract function access($cursor): void;
+    public abstract function access(mixed $cursor): void;
 
     /**
      * Currents the current offset.
-     *
-     * @return integer|string
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->currentOffset;
     }
 
     /**
      * Gets the item count.
-     *
-     * @return integer
      */
     public final function count(): int
     {
@@ -77,8 +70,6 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
 
     /**
      * Gets the total results.
-     *
-     * @return integer
      */
     public function getTotalResults(): int
     {
@@ -87,9 +78,6 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
 
     /**
      * Sets the total results.
-     *
-     * @param integer $results
-     * @return void
      */
     protected final function setTotalResults(int $results): void
     {
@@ -98,8 +86,6 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
 
     /**
      * Checks if the current offset exists in the cache.
-     *
-     * @return bool
      */
     public final function valid(): bool
     {
@@ -108,22 +94,16 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
 
     /**
      * Resets the iterator to the first item.
-     *
-     * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->currentOffset = 0;
     }
 
     /**
      * Updates the total result count and adds the new items onto the cache.
-     *
-     * @param integer $totalResults
-     * @param array $items
-     * @return void
      */
-    public final function update(int $totalResults, array $items, $customCursor = null)
+    public final function update(int $totalResults, array $items, mixed $customCursor = null): void
     {
         $this->setTotalResults($totalResults);
 
@@ -134,11 +114,8 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
 
     /**
      * Set whether to force the iterator to keep accessing values or not.
-     *
-     * @param boolean $value
-     * @return void
      */
-    public function force(bool $value)
+    public function force(bool $value): void
     {
         $this->force = $value;
     }
@@ -147,8 +124,6 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
      * Points the offset to the next item.
      * 
      * Will request data from the API whenever necessary.
-     *
-     * @return void
      */
     public function next(): void
     {
@@ -170,11 +145,8 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
 
     /**
      * Gets an item from cache, or from the API resource if necessary, by an offset.
-     *
-     * @param integer|string $offset
-     * @return object
      */
-    public function getFromOffset($offset): object
+    public function getFromOffset(mixed $offset): object
     {
         if (is_null($offset)) {
             throw new InvalidArgumentException("Offset cannot be null.");
@@ -193,11 +165,8 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
 
     /**
      * Ensures that an offset exists before trying to access it by an offset.
-     *
-     * @param integer|string $offset
-     * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         try {
             return $offset >= 0 && $offset < $this->getTotalResults();
@@ -208,16 +177,16 @@ abstract class AbstractApiIterator extends Api implements Iterator, Countable
 
     /**
      * Appends a new collection of items onto the cache.
-     *
-     * @param array $items
-     * @return void
      */
-    protected final function appendToCache(array $items)
+    protected final function appendToCache(array $items): void
     {
         $this->cache = array_merge($this->cache, $items);
     }
 
-    public function first()
+    /**
+     * Gets the first item in the iterator.
+     */
+    public function first(): object
     {
         $this->rewind();
 

--- a/src/Iterator/CloudMediaGalleryIterator.php
+++ b/src/Iterator/CloudMediaGalleryIterator.php
@@ -32,7 +32,7 @@ class CloudMediaGalleryIterator extends AbstractApiIterator
         $this->update($this->limit, $results->ugcDocument, $results->nextCursorMark);
     }
 
-    public function current()
+    public function current(): object
     {
         return Media::fromObject(
             $this->cloudMediaGalleryFactory->getHttpClient(),

--- a/src/Iterator/Filter/GroupMembersFilter.php
+++ b/src/Iterator/Filter/GroupMembersFilter.php
@@ -16,7 +16,7 @@ class GroupMembersFilter extends FilterIterator
         $this->includesOnly = $includesOnly;
     }
    
-    public function accept()
+    public function accept(): bool
     {
         $thread = $this->current();
 

--- a/src/Iterator/Filter/MessageTypeFilter.php
+++ b/src/Iterator/Filter/MessageTypeFilter.php
@@ -7,10 +7,7 @@ use FilterIterator;
 
 class MessageTypeFilter extends FilterIterator
 {
-    /**
-     * @var string
-     */
-    private $type;
+    private string $type;
 
     public function __construct(Iterator $iterator, string $type)
     {
@@ -18,7 +15,7 @@ class MessageTypeFilter extends FilterIterator
         $this->type = $type;
     }
 
-    public function accept()
+    public function accept(): bool
     {
         $a = $this->current();
         $b = $this->type;

--- a/src/Iterator/Filter/TitleIdFilter.php
+++ b/src/Iterator/Filter/TitleIdFilter.php
@@ -15,7 +15,7 @@ class TitleIdFilter extends FilterIterator
         $this->value = $value;
     }
 
-    public function accept()
+    public function accept(): bool
     {
         return $this->current()->titleId() === $this->value;
     }

--- a/src/Iterator/Filter/TrophyGroup/DetailFilter.php
+++ b/src/Iterator/Filter/TrophyGroup/DetailFilter.php
@@ -17,7 +17,7 @@ class DetailFilter extends FilterIterator
         $this->detail = $detail;
     }
    
-    public function accept()
+    public function accept(): bool
     {
         return stripos($this->current()->detail(), $this->detail) !== false;
     }

--- a/src/Iterator/Filter/TrophyGroup/DetailFilter.php
+++ b/src/Iterator/Filter/TrophyGroup/DetailFilter.php
@@ -6,10 +6,7 @@ use FilterIterator;
 
 class DetailFilter extends FilterIterator
 {
-	/**
-	 * @var string
-	 */
-    private $detail;
+    private string $detail;
    
     public function __construct(Iterator $iterator, string $detail)
     {

--- a/src/Iterator/Filter/TrophyGroup/NameFilter.php
+++ b/src/Iterator/Filter/TrophyGroup/NameFilter.php
@@ -14,7 +14,7 @@ class NameFilter extends FilterIterator
         $this->groupName = $groupName;
     }
    
-    public function accept()
+    public function accept(): bool
     {
         return stripos($this->current()->name(), $this->groupName) !== false;
     }

--- a/src/Iterator/Filter/TrophyGroup/TrophyTypeFilter.php
+++ b/src/Iterator/Filter/TrophyGroup/TrophyTypeFilter.php
@@ -21,7 +21,7 @@ class TrophyTypeFilter extends FilterIterator
         $this->count = $count;
     }
    
-    public function accept()
+    public function accept(): bool
     {
         return $this->parse($this->current()->trophyCount($this->trophyType), $this->count);
     }

--- a/src/Iterator/Filter/TrophyTitle/TrophyTitleHasGroupsFilter.php
+++ b/src/Iterator/Filter/TrophyTitle/TrophyTitleHasGroupsFilter.php
@@ -15,7 +15,7 @@ class TrophyTitleHasGroupsFilter extends FilterIterator
         $this->value = $value;
     }
 
-    public function accept()
+    public function accept(): bool
     {
         return $this->current()->hasTrophyGroups() === $this->value;
     }

--- a/src/Iterator/Filter/TrophyTitle/TrophyTitleNameFilter.php
+++ b/src/Iterator/Filter/TrophyTitle/TrophyTitleNameFilter.php
@@ -15,7 +15,7 @@ class TrophyTitleNameFilter extends FilterIterator
         $this->titleName = $titleName;
     }
 
-    public function accept()
+    public function accept(): bool
     {
         return stripos($this->current()->name(), $this->titleName) !== false;
     }

--- a/src/Iterator/Filter/User/CloseFriendFilter.php
+++ b/src/Iterator/Filter/User/CloseFriendFilter.php
@@ -12,7 +12,7 @@ class CloseFriendFilter extends FilterIterator
         parent::__construct($iterator);
     }
 
-    public function accept()
+    public function accept(): bool
     {
         // Kind of a hack so we don't need to fetch the whole user's profile for each iteration.
         // This property will only exist if the user is a close friend, otherwise it is completely omitted.

--- a/src/Iterator/Filter/User/OnlineIdFilter.php
+++ b/src/Iterator/Filter/User/OnlineIdFilter.php
@@ -15,7 +15,7 @@ class OnlineIdFilter extends FilterIterator
         $this->onlineId = $onlineId;
     }
 
-    public function accept()
+    public function accept(): bool
     {
         return stripos($this->current()->onlineId(), $this->onlineId) !== false;
     }

--- a/src/Iterator/Filter/User/VerifiedUserFilter.php
+++ b/src/Iterator/Filter/User/VerifiedUserFilter.php
@@ -12,7 +12,7 @@ class VerifiedUserFilter extends FilterIterator
         parent::__construct($iterator);
     }
 
-    public function accept()
+    public function accept(): bool
     {
         return $this->current()->isVerified() === true;
     }

--- a/src/Iterator/FriendsListIterator.php
+++ b/src/Iterator/FriendsListIterator.php
@@ -18,7 +18,7 @@ class FriendsListIterator extends AbstractApiIterator
         $this->access(0);
     }
 
-    public function access($cursor): void
+    public function access(mixed $cursor): void
     {
         $results = $this->get('userProfile/v1/internal/users/' . $this->userAccountId . '/friends', [
             'limit' => $this->limit,

--- a/src/Iterator/GameListIterator.php
+++ b/src/Iterator/GameListIterator.php
@@ -19,7 +19,7 @@ class GameListIterator extends AbstractApiIterator
         $this->access(0);
     }
 
-    public function access($cursor): void
+    public function access(mixed $cursor): void
     {
         $body = [
             'limit' => $this->limit,
@@ -31,7 +31,7 @@ class GameListIterator extends AbstractApiIterator
         $this->update($results->totalItemCount, $results->titles);
     }
 
-    public function current()
+    public function current(): GameTitle
     {
         return GameTitle::fromObject(
             $this->gameListFactory,

--- a/src/Iterator/GroupsIterator.php
+++ b/src/Iterator/GroupsIterator.php
@@ -23,7 +23,7 @@ class GroupsIterator extends AbstractApiIterator
         $this->access(0);
     }
 
-    public function access($cursor): void
+    public function access(mixed $cursor): void
     {
         $results = $this->get('gamingLoungeGroups/v1/members/me/groups', [
             'favoriteFilter' => $this->groupsFactory->favorited ? 'favorite' : 'notFavorite',
@@ -35,7 +35,7 @@ class GroupsIterator extends AbstractApiIterator
         $this->update($results->totalGroupCount, $results->groups);
     }
 
-    public function current()
+    public function current(): Group
     {
         return Group::fromObject(
             $this->groupsFactory,

--- a/src/Iterator/MessagesIterator.php
+++ b/src/Iterator/MessagesIterator.php
@@ -33,7 +33,7 @@ class MessagesIterator extends AbstractApiIterator
         $this->access(null);
     }
 
-    public function access($cursor): void
+    public function access(mixed $cursor): void
     {
         $params = [];
 
@@ -66,7 +66,7 @@ class MessagesIterator extends AbstractApiIterator
         }
     }
 
-    public function current()
+    public function current(): AbstractMessage
     {
         return AbstractMessage::create(
             $this->thread,

--- a/src/Iterator/StoreSearchIterator.php
+++ b/src/Iterator/StoreSearchIterator.php
@@ -13,24 +13,18 @@ class StoreSearchIterator extends AbstractApiIterator
 {
     /**
      * The search query.
-     *
-     * @var string
      */
-    protected $query;
+    protected string $query;
 
     /**
      * The language to search with.
-     *
-     * @var string
      */
-    protected $languageCode;
+    protected string $languageCode;
 
     /**
      * The country code.
-     *
-     * @var string
      */
-    protected $countryCode;
+    protected string $countryCode;
 
     public function __construct(StoreFactory $storeFactory, string $query, string $languageCode = 'en', string $countryCode = 'us')
     {
@@ -46,7 +40,7 @@ class StoreSearchIterator extends AbstractApiIterator
         $this->access('');
     }
 
-    public function access($cursor): void
+    public function access(mixed $cursor): void
     {
         $results = $this->postJson('search/v1/universalSearch', [
             'age' => '69',
@@ -76,7 +70,7 @@ class StoreSearchIterator extends AbstractApiIterator
         }
     }
 
-    public function current()
+    public function current(): Concept
     {
         $concept = $this->getFromOffset($this->currentOffset)->conceptProductMetadata;
         

--- a/src/Iterator/TrophyGroupsIterator.php
+++ b/src/Iterator/TrophyGroupsIterator.php
@@ -10,10 +10,8 @@ class TrophyGroupsIterator extends AbstractApiIterator
 {
     /**
      * Current trophy title.
-     *
-     * @var AbstractTrophyTitle
      */
-    private $title;
+    private AbstractTrophyTitle $title;
 
     public function __construct(AbstractTrophyTitle $title)
     {
@@ -24,7 +22,7 @@ class TrophyGroupsIterator extends AbstractApiIterator
         $this->access(0);
     }
 
-    public function access($cursor): void
+    public function access(mixed $cursor): void
     {
         if ($this->title instanceof UserTrophyTitle)
         {
@@ -48,7 +46,7 @@ class TrophyGroupsIterator extends AbstractApiIterator
         $this->update(count($results->trophyGroups), $results->trophyGroups);
     }
 
-    public function current()
+    public function current(): TrophyGroup
     {
         if ($this->title instanceof UserTrophyTitle)
         {

--- a/src/Iterator/TrophyIterator.php
+++ b/src/Iterator/TrophyIterator.php
@@ -10,10 +10,8 @@ class TrophyIterator extends AbstractApiIterator
 {
     /**
      * Current trophy title.
-     *
-     * @var TrophyGroup
      */
-    private $trophyGroup;
+    private TrophyGroup $trophyGroup;
     
     public function __construct(TrophyGroup $trophyGroup)
     {
@@ -24,7 +22,7 @@ class TrophyIterator extends AbstractApiIterator
         $this->access(0);
     }
 
-    public function access($cursor): void
+    public function access(mixed $cursor): void
     {
         if ($this->trophyGroup->title() instanceof UserTrophyTitle)
         {
@@ -49,7 +47,7 @@ class TrophyIterator extends AbstractApiIterator
         $this->update($results->totalItemCount, $results->trophies);
     }
 
-    public function current()
+    public function current(): Trophy
     {
         return Trophy::fromObject(
             $this->trophyGroup,

--- a/src/Iterator/TrophyTitlesIterator.php
+++ b/src/Iterator/TrophyTitlesIterator.php
@@ -6,9 +6,9 @@ use Tustin\PlayStation\Model\Trophy\UserTrophyTitle;
 
 class TrophyTitlesIterator extends AbstractApiIterator
 {
-    private $platforms;
+    // private $platforms;
 
-    private $trophyTitlesFactory;
+    private TrophyTitlesFactory $trophyTitlesFactory;
     
     public function __construct(TrophyTitlesFactory $trophyTitlesFactory)
     {
@@ -16,14 +16,14 @@ class TrophyTitlesIterator extends AbstractApiIterator
 
         $this->trophyTitlesFactory = $trophyTitlesFactory;
         
-        $this->platforms = implode(',', $trophyTitlesFactory->getPlatforms());
+        // $this->platforms = implode(',', $trophyTitlesFactory->getPlatforms());
 
         $this->limit = 100;
         
         $this->access(0);
     }
 
-    public function access($cursor): void
+    public function access(mixed $cursor): void
     {
         $body = [
             'limit' => $this->limit,
@@ -35,7 +35,7 @@ class TrophyTitlesIterator extends AbstractApiIterator
         $this->update($results->totalItemCount, $results->trophyTitles);
     }
 
-    public function current()
+    public function current(): UserTrophyTitle
     {
 		$title = new UserTrophyTitle($this->trophyTitlesFactory->getHttpClient());
 		$title->setFactory($this->trophyTitlesFactory);

--- a/src/Iterator/UsersSearchIterator.php
+++ b/src/Iterator/UsersSearchIterator.php
@@ -11,31 +11,23 @@ class UsersSearchIterator extends AbstractApiIterator
 {
     /**
      * The search query.
-     *
-     * @var string
      */
-    protected $query;
+    protected string $query;
 
     /**
      * The language to search with.
-     *
-     * @var string
      */
-    protected $languageCode;
+    protected string $languageCode;
 
     /**
      * The country code.
-     *
-     * @var string
      */
-    protected $countryCode;
+    protected string $countryCode;
 
     /**
      * The users factory.
-     *
-     * @var UsersFactory
      */
-    private $usersFactory;
+    private UsersFactory $usersFactory;
 
     public function __construct(UsersFactory $usersFactory, string $query, string $languageCode = 'en', string $countryCode = 'us')
     {
@@ -52,7 +44,7 @@ class UsersSearchIterator extends AbstractApiIterator
         $this->access('');
     }
 
-    public function access($cursor): void
+    public function access(mixed $cursor): void
     {
         // @TODO: Since the search function seems to be streamlined now, we could probably throw this into the abstract api iterator??
         $results = $this->postJson('search/v1/universalSearch', [
@@ -76,7 +68,7 @@ class UsersSearchIterator extends AbstractApiIterator
         $this->update($domainResponse->totalResultCount, $domainResponse->results, $domainResponse->next ?? "");
     }
 
-    public function current()
+    public function current(): User
     {
         $socialMetadata = $this->getFromOffset($this->currentOffset)->socialMetadata;
         //$token = $this->getFromOffset($this->currentOffset)->id; // Do we need this??

--- a/src/Model.php
+++ b/src/Model.php
@@ -25,15 +25,11 @@ abstract class Model extends Api
 
     /**
      * Fetches the model data from the API.
-     *
-     * @return object
      */
     abstract public function fetch(): object;
 
     /**
      * Performs the fetch method while flagging the model as being fetched.
-     *
-     * @return object
      */
     private function performFetch(): object
     {
@@ -49,12 +45,8 @@ abstract class Model extends Api
 
     /**
      * Plucks an API property from the cache. Will populate cache if necessary.
-     *
-     * @param string $property
-     * @param bool $ignoreCache Ignores the existing cache and fetches fresh API data.
-     * @return mixed
      */
-    public function pluck($property, $ignoreCache = false)
+    public function pluck(string $property, bool $ignoreCache = false): mixed
     {
         $pieces = explode('.', $property);
 
@@ -96,8 +88,6 @@ abstract class Model extends Api
 
     /**
      * Checks if data has been fetched from the API.
-     *
-     * @return boolean
      */
     protected function hasFetched(): bool
     {
@@ -106,11 +96,8 @@ abstract class Model extends Api
 
     /**
      * Sets the cache property.
-     *
-     * @param object $data
-     * @return void
      */
-    public function setCache($data): void
+    public function setCache(object $data): void
     {
         // So this is bad and probably slow, but it's less annoying than some recursive method.
         $this->cache = json_decode(json_encode($data, JSON_FORCE_OBJECT), true);
@@ -118,8 +105,6 @@ abstract class Model extends Api
 
     /**
      * Gets the current model's cache.
-     *
-     * @return array
      */
     public function getCache(): array
     {
@@ -128,8 +113,6 @@ abstract class Model extends Api
 
     /**
      * Gets the factory for this model.
-     *
-     * @return FactoryInterface
      */
     public function getFactory(): FactoryInterface
     {
@@ -138,11 +121,8 @@ abstract class Model extends Api
 
     /**
      * Sets the factory for this model
-     *
-     * @param FactoryInterface $factory
-     * @return void
      */
-    public function setFactory($factory): void
+    public function setFactory(FactoryInterface $factory): void
     {
         $this->factory = $factory;
     }

--- a/src/Model/GameTitle.php
+++ b/src/Model/GameTitle.php
@@ -7,10 +7,7 @@ use Tustin\PlayStation\Factory\GameListFactory;
 
 class GameTitle extends Model
 {
-    /**
-     * @var string
-     */
-    private $id;
+    private string $id;
     
     public function __construct(GameListFactory $gameListFactory, string $id)
     {

--- a/src/Model/GameTitle.php
+++ b/src/Model/GameTitle.php
@@ -7,13 +7,9 @@ use Tustin\PlayStation\Factory\GameListFactory;
 
 class GameTitle extends Model
 {
-    private string $id;
-    
-    public function __construct(GameListFactory $gameListFactory, string $id)
+    public function __construct(GameListFactory $gameListFactory, private string $id)
     {
         parent::__construct($gameListFactory->getHttpClient());
-
-        $this->id = $id;
     }
 
     public static function fromObject(GameListFactory $gameListFactory, object $data): GameTitle

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -11,15 +11,11 @@ use Tustin\PlayStation\Model\Message\AbstractMessage;
 
 class Group extends Model
 {
-    private string $groupId;
-
     private array $members;
 
-    public function __construct(GroupsFactory $groupsFactory, string $groupId)
+    public function __construct(GroupsFactory $groupsFactory, private string $groupId)
     {
         parent::__construct($groupsFactory->getHttpClient());
-
-        $this->groupId = $groupId;
     }
 
     public static function fromObject(GroupsFactory $groupsFactory, object $data)

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -11,13 +11,9 @@ use Tustin\PlayStation\Enum\TranscodeStatusType;
 
 class Media extends Model
 {
-	private string $ugcId;
-
-	public function __construct(Client $client, string $ugcId)
+	public function __construct(Client $client, private string $ugcId)
 	{
 		parent::__construct($client);
-
-		$this->ugcId = $ugcId;
 	}
 
 	public static function fromObject(Client $client, object $data): Media

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -1,22 +1,17 @@
 <?php
 namespace Tustin\PlayStation\Model;
 
-use Exception;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Tustin\PlayStation\Model;
 use Tustin\PlayStation\Enum\UgcType;
 use Tustin\PlayStation\Model\Trophy\TrophyTitle;
-use Tustin\PlayStation\Exception\MissingKeyPairIdException;
-use GuzzleHttp\Cookie\SetCookie as CookieParser;
 use Tustin\PlayStation\Enum\CloudStatusType;
 use Tustin\PlayStation\Enum\TranscodeStatusType;
 
 class Media extends Model
 {
 	private string $ugcId;
-
-	private array $cookies = [];
 
 	public function __construct(Client $client, string $ugcId)
 	{
@@ -122,11 +117,11 @@ class Media extends Model
 	{
 		switch ($this->type())
 		{
-			case UgcType::video():
+			case UgcType::Video:
 				return $this->generateUrls()->downloadUrl;
 			break;
 
-			case UgcType::image():
+			case UgcType::Image:
 				return $this->generateUrls()->screenshotUrl;
 			break;
 		}
@@ -140,23 +135,6 @@ class Media extends Model
 	private function generateUrls(): object
 	{
 		return $this->get('gameMediaService/v2/c2s/ugc/' . $this->id() . '/url');
-
-		// Lol so you dont need to do this below.
-		// $url .= '?';
-
-		// if (array_key_exists('CloudFront-Policy', $this->cookies)) {
-		// 	$url .= 'Policy=' . $this->cookies['CloudFront-Policy'] . '&';
-		// }
-
-		// if (array_key_exists('CloudFront-Key-Pair-Id', $this->cookies)) {
-		// 	$url .= 'Key-Pair-Id=' . $this->cookies['CloudFront-Key-Pair-Id'] . '&';
-		// }
-
-		// if (array_key_exists('CloudFront-Signature', $this->cookies)) {
-		// 	$url .= 'Signature=' . $this->cookies['CloudFront-Signature'] . '&';
-		// }
-
-		// return $url;
 	}
 
 	public function fetch(): object

--- a/src/Model/Message/AbstractMessage.php
+++ b/src/Model/Message/AbstractMessage.php
@@ -15,7 +15,7 @@ abstract class AbstractMessage extends Model
      *
      * @var MessageThread
      */
-    private $thread;
+    private MessageThread $thread;
 
     public static function fromObject(MessageThread $thread, object $messageData)
     {
@@ -97,13 +97,13 @@ abstract class AbstractMessage extends Model
     public static function create(MessageThread $thread, object $messageData): AbstractMessage
     {
         switch (new MessageType($messageData->messageType)) {
-            case MessageType::audio():
+            case MessageType::Audio:
                 return AudioMessage::fromObject($thread, $messageData);
-            case MessageType::image():
+            case MessageType::Image:
                 return ImageMessage::fromObject($thread, $messageData);
-            case MessageType::video():
+            case MessageType::Video:
                 return VideoMessage::fromObject($thread, $messageData);
-            case MessageType::sticker():
+            case MessageType::Sticker:
                 return StickerMessage::fromObject($thread, $messageData);
             default:
                 // We'll just default to a text message because there are certain types of messages (new voice chat, etc) that are basically text messages.

--- a/src/Model/Message/AbstractMessage.php
+++ b/src/Model/Message/AbstractMessage.php
@@ -12,8 +12,6 @@ abstract class AbstractMessage extends Model
 {
     /**
      * The message thread this message is in.
-     *
-     * @var MessageThread
      */
     private MessageThread $thread;
 

--- a/src/Model/Message/AudioMessage.php
+++ b/src/Model/Message/AudioMessage.php
@@ -9,7 +9,7 @@ class AudioMessage extends AbstractMessage
 {
     public function type(): MessageType
     {
-        return MessageType::audio();
+        return MessageType::Audio;
     }
 
 	public function fetch(): object

--- a/src/Model/Message/ImageMessage.php
+++ b/src/Model/Message/ImageMessage.php
@@ -30,7 +30,7 @@ class ImageMessage extends AbstractMessage
 
     public function type(): MessageType
     {
-        return MessageType::image();
+        return MessageType::Image;
     }
 
     public function fetch(): object

--- a/src/Model/Message/Sendable.php
+++ b/src/Model/Message/Sendable.php
@@ -4,5 +4,5 @@ namespace Tustin\PlayStation\Model\Message;
 
 interface Sendable
 {
-    public function build();
+    public function build(): array;
 }

--- a/src/Model/Message/StickerMessage.php
+++ b/src/Model/Message/StickerMessage.php
@@ -29,7 +29,7 @@ class StickerMessage extends AbstractMessage
 
     public function type(): MessageType
     {
-        return MessageType::sticker();
+        return MessageType::Sticker;
     }
 
     public function fetch(): object

--- a/src/Model/Message/TextMessage.php
+++ b/src/Model/Message/TextMessage.php
@@ -17,13 +17,13 @@ class TextMessage extends AbstractMessage implements Sendable
 
     public function type(): MessageType
     {
-        return MessageType::text();
+        return MessageType::Text;
     }
 
     public function build()
     {
         return [
-            'messageType' => $this->type()->getValue(),
+            'messageType' => $this->type(),
             'body' => $this->textMessage
         ];
     }

--- a/src/Model/Message/TextMessage.php
+++ b/src/Model/Message/TextMessage.php
@@ -8,11 +8,8 @@ use Tustin\PlayStation\Model\Message\AbstractMessage;
 
 class TextMessage extends AbstractMessage implements Sendable
 {
-    private $textMessage;
-
-    public function __construct(string $textMessage)
+    public function __construct(private string $textMessage)
     {
-        $this->textMessage = $textMessage;
     }
 
     public function type(): MessageType
@@ -20,7 +17,7 @@ class TextMessage extends AbstractMessage implements Sendable
         return MessageType::Text;
     }
 
-    public function build()
+    public function build(): array
     {
         return [
             'messageType' => $this->type(),

--- a/src/Model/Message/VideoMessage.php
+++ b/src/Model/Message/VideoMessage.php
@@ -20,7 +20,7 @@ class VideoMessage extends AbstractMessage
 
     public function type(): MessageType
     {
-        return MessageType::video();
+        return MessageType::Video;
     }
 
     public function fetch(): object

--- a/src/Model/MessageThread.php
+++ b/src/Model/MessageThread.php
@@ -10,16 +10,9 @@ use Tustin\PlayStation\Model\Message\AbstractMessage;
 
 class MessageThread extends Model
 {
-    private Group $group;
-
-    private string $threadId;
-
-    public function __construct(Group $group, string $threadId)
+    public function __construct(private Group $group, private string $threadId)
     {
         parent::__construct($group->getHttpClient());
-
-        $this->group = $group;
-        $this->threadId = $threadId;
     }
 
     public static function fromObject(Group $group, object $data)

--- a/src/Model/MessageThread.php
+++ b/src/Model/MessageThread.php
@@ -10,15 +10,9 @@ use Tustin\PlayStation\Model\Message\AbstractMessage;
 
 class MessageThread extends Model
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private Group $group;
 
-    /**
-     * @var string
-     */
-    private $threadId;
+    private string $threadId;
 
     public function __construct(Group $group, string $threadId)
     {
@@ -38,9 +32,6 @@ class MessageThread extends Model
 
     /**
      * Sends a message to the message thread.
-     *
-     * @param Sendable $message
-     * @return Message
      */
     public function sendMessage(Sendable $message): AbstractMessage
     {

--- a/src/Model/Store/Concept.php
+++ b/src/Model/Store/Concept.php
@@ -6,13 +6,9 @@ use Tustin\PlayStation\Model;
 
 class Concept extends Model
 {
-    private string $conceptId;
-    
-	public function __construct(Client $client, string $conceptId)
+	public function __construct(Client $client, private string $conceptId)
 	{
 		parent::__construct($client);
-
-		$this->conceptId = $conceptId;
 	}
 
     public static function fromObject(Client $client, object $data)

--- a/src/Model/Trophy/AbstractTrophyTitle.php
+++ b/src/Model/Trophy/AbstractTrophyTitle.php
@@ -16,15 +16,9 @@ use Tustin\PlayStation\Factory\TrophyGroupsFactory;
  */
 abstract class AbstractTrophyTitle extends Model
 {
-    /**
-	 * @var string
-	 */
-	protected $npCommuncationId;
+	protected string $npCommuncationId;
 
-	/**
-	 * @var string
-	 */
-	protected $serviceName;
+	protected string $serviceName;
 
 	protected function setNpCommuncationId(string $npCommuncationId)
 	{

--- a/src/Model/Trophy/Trophy.php
+++ b/src/Model/Trophy/Trophy.php
@@ -20,6 +20,8 @@ class Trophy extends Model
     
     public function __construct(TrophyGroup $trophyGroup, int $id)
     {
+        parent::__construct($trophyGroup->getHttpClient());
+
         $this->trophyGroup = $trophyGroup;
         
         $this->id = $id;
@@ -190,7 +192,7 @@ class Trophy extends Model
      */
     public function fetch(): object
     {
-        return $this->get('trophy/v1/npCommunicationIds/' . $this->trophyGroup->title()->npCommunicationId()  . '/trophyGroups/'  . $this->trophyGroup->id() . '/trophies/' . $this->id(), [
+        return $this->get('trophy/v1/npCommunicationIds/' . $this->trophyGroup->title()->npCommunicationId()  . '/trophies/' . $this->id(), [
             'npServiceName' => $this->trophyGroup->title()->serviceName()
         ]);
     }

--- a/src/Model/Trophy/Trophy.php
+++ b/src/Model/Trophy/Trophy.php
@@ -6,25 +6,9 @@ use Tustin\PlayStation\Enum\TrophyType;
 
 class Trophy extends Model
 {
-    /**
-     * The trophy group this trophy is in.
-     *
-     * @var TrophyGroup
-     */
-    private $trophyGroup;
-    
-    /**
-     * @var int
-     */
-    private $id;
-    
-    public function __construct(TrophyGroup $trophyGroup, int $id)
+    public function __construct(private TrophyGroup $trophyGroup, private int $id)
     {
         parent::__construct($trophyGroup->getHttpClient());
-
-        $this->trophyGroup = $trophyGroup;
-        
-        $this->id = $id;
     }
 
     public static function fromObject(TrophyGroup $trophyGroup, object $data): Trophy

--- a/src/Model/Trophy/TrophyGroup.php
+++ b/src/Model/Trophy/TrophyGroup.php
@@ -8,21 +8,14 @@ use Tustin\PlayStation\Factory\TrophyFactory;
 
 class TrophyGroup extends Model
 {
-    private $trophyTitle;
-	
-    private $groupId;
-    private $groupName;
-    private $groupDetail;
-    private $groupIconUrl;
-
-    public function __construct(AbstractTrophyTitle $trophyTitle, string $groupId, string $groupName = '', string $groupIconUrl = '', string $groupDetail = '')
+    public function __construct(
+        private AbstractTrophyTitle $trophyTitle, 
+        private string $groupId, 
+        private string $groupName = '',
+        private string $groupIconUrl = '', 
+        private string $groupDetail = '')
     {
         parent::__construct($trophyTitle->getHttpClient());
-        $this->trophyTitle = $trophyTitle;
-        $this->groupId = $groupId;
-        $this->groupName = $groupName;
-        $this->groupDetail = $groupDetail;
-        $this->groupIconUrl = $groupIconUrl;
     }
 
     public static function fromObject(AbstractTrophyTitle $trophyTitle, object $data): TrophyGroup
@@ -153,13 +146,13 @@ class TrophyGroup extends Model
     {
         switch ($trophyType)
         {
-            case TrophyType::bronze():
+            case TrophyType::Bronze:
                 return $this->bronze();
-            case TrophyType::silver():
+            case TrophyType::Silver:
                 return $this->silver();
-            case TrophyType::gold():
+            case TrophyType::Gold:
                 return $this->gold();
-            case TrophyType::platinum():
+            case TrophyType::Platinum:
                 return (int)$this->hasPlatinum();
             default:
                 throw new InvalidArgumentException("Trophy type [$trophyType] does not contain a count method.");

--- a/src/Model/Trophy/TrophySummary.php
+++ b/src/Model/Trophy/TrophySummary.php
@@ -7,16 +7,10 @@ use Tustin\PlayStation\Model\User;
 
 class TrophySummary extends Model
 {
-    /**
-     * The user for the trophy summary.
-     *
-     * @var User
-     */
-    private $user;
-
-    public function __construct(User $user)
+    public function __construct(private User $user)
     {
         $this->user = $user;
+
         parent::__construct($user->getHttpClient());
     }
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -13,23 +13,14 @@ use Tustin\PlayStation\Factory\TrophyTitlesFactory;
 class User extends Model
 {
     /**
-     * The user's account id.
-     *
-     * @var string
-     */
-    private string $accountId;
-
-    /**
      * Constructs a new user object.
      *
      * @param UsersFactory $usersFactory
      * @param string $accountId
      */
-    public function __construct(Client $client, string $accountId)
+    public function __construct(Client $client, private string $accountId)
     {
         parent::__construct($client);
-
-        $this->accountId = $accountId;
     }
 
     public static function fromObject(Client $client, object $data)

--- a/src/OAuthToken.php
+++ b/src/OAuthToken.php
@@ -4,12 +4,13 @@ namespace Tustin\PlayStation;
 
 use Carbon\Carbon;
 
-
 class OAuthToken
 {
     private string $token;
 
     private Carbon $expiration;
+
+    private int $seconds;
 
     public function __construct(string $token, int $expiresIn)
     {
@@ -17,6 +18,7 @@ class OAuthToken
             throw new \InvalidArgumentException('expiresIn has to be an integer > 0');
         }
         $this->token = $token;
+        $this->seconds = $expiresIn;
         $this->expiration = Carbon::now()->addSeconds($expiresIn);
     }
 
@@ -32,11 +34,17 @@ class OAuthToken
 
     /**
      * Gets the OAuth token's expiration date and time.
-     *
-     * @return \DateTime
      */
     public function getExpiration(): \DateTime
     {
         return $this->expiration;
+    }
+
+    /**
+     * Gets the OAuth token's expiration in seconds.
+     */
+    public function getExpirationSeconds(): int
+    {
+        return $this->seconds;
     }
 }

--- a/src/Traits/OperandParser.php
+++ b/src/Traits/OperandParser.php
@@ -7,19 +7,14 @@ trait OperandParser
 {
     /**
      * The operator being used.
-     *
-     * @var string
      */
-    protected $operator;
+    protected string $operator;
+
     /**
      * Parses a custom operator value.
-     *
-     * @param mixed $lhs
-     * @param mixed $rhs
-     * @return bool
      * @throws RuntimeException
      */
-    protected function parse($lhs, $rhs): bool
+    protected function parse(mixed $lhs, mixed $rhs): bool
     {
         if (!$this->operator)
         {


### PR DESCRIPTION
- Adds `mixed` type where possible
- Switched `myclabs/php-enum` to native PHP 8.1 enum
- Updates Guzzle to 7.5
- Fixed various missing class property type declarations
- Fixes various missing function parameters
- Removes `myclabs/php-enum` dependency