### PR TITLE
Fixing Login with Refresh Token Issue

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -136,7 +136,10 @@ class Client extends AbstractClient
             'refresh_token' => $refreshToken,
             'grant_type' => 'refresh_token',
             'token_format' => 'jwt',
-        ], ['Authorization' => 'Basic MDk1MTUxNTktNzIzNy00MzcwLTliNDAtMzgwNmU2N2MwODkxOnVjUGprYTV0bnRCMktxc1A=']);
+        ], [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'Authorization' => 'Basic MDk1MTUxNTktNzIzNy00MzcwLTliNDAtMzgwNmU2N2MwODkxOnVjUGprYTV0bnRCMktxc1A='
+        ]);
 
         $this->finalizeLogin($response);
     }


### PR DESCRIPTION
The login with refresh token for some reason requires the Content-Type to be set.

This is based on [the node library](https://github.com/achievements-app/psn-api/blob/main/src/authenticate/exchangeRefreshTokenForAuthTokens.ts).

That seems to have fixed it for me in my app.