### PR TITLE
Add new enum value in ConsoleType

### DIFF
--- a/src/Enum/ConsoleType.php
+++ b/src/Enum/ConsoleType.php
@@ -8,4 +8,5 @@ enum ConsoleType: string
     case PS3 = 'PS3';
     case PS4 = 'PS4';
     case PS5 = 'PS5';
+    case PC = 'PSPC';
 }


### PR DESCRIPTION
fix the error: Value 'PSPC' is not part of the enum Tustin\PlayStation\Enum\ConsoleType